### PR TITLE
not use subshell in __zplug::job::handle::flock()

### DIFF
--- a/base/job/handle.zsh
+++ b/base/job/handle.zsh
@@ -35,8 +35,8 @@ __zplug::job::handle::flock()
         touch "$file"
     fi
 
-    (
-    until zsystem flock -t 3 "$file"
+    local lock_fd
+    until zsystem flock -t 3 -f lock_fd "$file"
     do
         cant_lock=$status
         if (( (++retry) > max )); then
@@ -60,7 +60,7 @@ __zplug::job::handle::flock()
     else
         print    "$contents" >>|"$file"
     fi >>|"$file"
-    )
+    zsystem flock -u $lock_fd
 }
 
 __zplug::job::handle::state()


### PR DESCRIPTION
Fix: #4